### PR TITLE
create `~/.meshery` in the container when adapter starts

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,15 @@ var (
 	serviceName = "nginx-adaptor"
 )
 
+// creates the ~/.meshery directory
+func init() {
+	err := os.MkdirAll(path.Join(config.RootPath(), "bin"), 0750)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(0)
+	}
+}
+
 // main is the entrypoint of the adaptor
 func main() {
 


### PR DESCRIPTION
Signed-off-by: Rudraksh Pareek <rudrakshpareek3601@gmail.com>

**Description**

This PR fixes 
```
time="2021-08-27T12:07:31Z" level=error msg="Config File \"nginx\" Not Found in \"[/root/.meshery]\"" app=nginx-adaptor code=1005 probable-cause= severity=2 short-description="Viper initialization failed with error: " suggested-remediation=
```

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
