### PR TITLE
add operation for enabling automatic sidecar injection

### DIFF
--- a/nginx/error.go
+++ b/nginx/error.go
@@ -26,6 +26,10 @@ var (
 	// during the process of applying helm chart
 	ErrApplyHelmChartCode = "1013"
 
+	// ErrLoadNamespaceCode represents the error generated
+	// during the process of applying namespace
+	ErrLoadNamespaceCode = "replace"
+
 	// ErrOpInvalid is an error when an invalid operation is requested
 	ErrOpInvalid = errors.New(ErrOpInvalidCode, errors.Alert, []string{"Invalid operation"}, []string{}, []string{}, []string{})
 
@@ -67,4 +71,9 @@ func ErrCustomOperation(err error) error {
 // ErrApplyHelmChart is the occurend while applying helm chart
 func ErrApplyHelmChart(err error) error {
 	return errors.New(ErrApplyHelmChartCode, errors.Alert, []string{"Error occured while applying Helm Chart"}, []string{err.Error()}, []string{}, []string{})
+}
+
+func ErrLoadNamespace(err error, s string ) error{
+	return errors.New(ErrLoadNamespaceCode, errors.Alert, []string{"Error occured while applying namespace "}, []string{err.Error()}, []string{}, []string{})
+
 }

--- a/nginx/error.go
+++ b/nginx/error.go
@@ -106,6 +106,6 @@ func ErrParseNginxCoreComponent(err error) error {
 
 // ErrLoadNamespace is the occurend while applying namespace
 func ErrLoadNamespace(err error, s string ) error{
-	return errors.New(ErrLoadNamespaceCode, errors.Alert, []string{"Error occured while applying namespace "}, []string{err.Error()}, []string{"Trying to access a namespace which is not available"}, []string{})
+	return errors.New(ErrLoadNamespaceCode, errors.Alert, []string{"Error occured while applying namespace "}, []string{err.Error()}, []string{"Trying to access a namespace which is not available"}, []string{"Verify presence of namespace. Confirm Meshery ServiceAccount permissions"})
 
 }

--- a/nginx/error.go
+++ b/nginx/error.go
@@ -73,6 +73,7 @@ func ErrApplyHelmChart(err error) error {
 	return errors.New(ErrApplyHelmChartCode, errors.Alert, []string{"Error occured while applying Helm Chart"}, []string{err.Error()}, []string{}, []string{})
 }
 
+// ErrLoadNamespace is the occurend while applying namespace
 func ErrLoadNamespace(err error, s string ) error{
 	return errors.New(ErrLoadNamespaceCode, errors.Alert, []string{"Error occured while applying namespace "}, []string{err.Error()}, []string{}, []string{})
 

--- a/nginx/sample_apps.go
+++ b/nginx/sample_apps.go
@@ -96,7 +96,7 @@ func (nginx *Nginx) LoadToMesh(namespace string, service string, remove bool) er
 func (nginx *Nginx) LoadNamespaceToMesh(namespace string, remove bool) error {
 	ns, err := nginx.KubeClient.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
 	if err != nil {
-		return err
+		return ErrLoadNamespace(err, namespace)
 	}
 
 	if ns.ObjectMeta.Labels == nil {
@@ -112,5 +112,5 @@ func (nginx *Nginx) LoadNamespaceToMesh(namespace string, remove bool) error {
 	if err != nil {
 		return err
 	}
-	return nil
+	return ErrLoadNamespace(err, namespace)
 }


### PR DESCRIPTION
Signed-off-by: Shreyas220 <shreyas.ny@gmail.com>

**Description**
- added operation to prepare targeted namespace and enable nginx-sm automatic sidecar injection on it
- fixes an instance of misused meshkit logger

This PR fixes #33


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
