### PR TITLE
nosec G107 and G304

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
         with:
-          args: ./... -exclude=G301,G304,G107,G101,G110
+          args: -exclude=G301,G304,G107,G101,G110 ./...
   tests:
     #  needs: [lint, error_check, static_check, vet, sec_check]
      name: Tests


### PR DESCRIPTION
Signed-off-by: Aisuko <urakiny@gmail.com>

**Description**

Due to we use the variable to append the `url` or `filepath`. So, we need `nosec` the `gosec` G107 and G304.  So, this PR make affect on the go vet CI check.

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
