### PR TITLE
Remove AMD64 hardcoding and kubeopenapi

### DIFF
--- a/.vscode/configurationCache.log
+++ b/.vscode/configurationCache.log
@@ -1,1 +1,1 @@
-{"buildTargets":["docker","docker-run","error","proto","protoc-setup","run"],"launchTargets":[],"customConfigurationProvider":{"workspaceBrowse":{"browsePath":[],"compilerArgs":[]},"fileIndex":[]}}
+{"buildTargets":["docker","docker-run","error","proto","protoc-setup","run","run-force-dynamic-reg"],"launchTargets":[],"customConfigurationProvider":{"workspaceBrowse":{"browsePath":[],"compilerArgs":[]},"fileIndex":[]}}

--- a/.vscode/targets.log
+++ b/.vscode/targets.log
@@ -6,33 +6,36 @@ make all --print-data-base --no-builtin-variables --no-builtin-rules --question
 # PARTICULAR PURPOSE.
 
 # This program built for i386-apple-darwin11.3.0
+ 
+make: *** No rule to make target `all'.  Stop.
 
-# Make data base, printed on Sun Mar 27 21:58:04 2022
+
+# Make data base, printed on Mon Aug  1 13:39:16 2022
 
 # Variables
 
 # automatic
 <D = $(patsubst %/,%,$(dir $<))
-# environment
-RUBY_VERSION = ruby-2.6.3
 # automatic
 ?F = $(notdir $?)
+# environment
+ELECTRON_NO_ATTACH_CONSOLE = 1
+# environment
+LC_CTYPE = UTF-8
 # environment
 VSCODE_LOG_NATIVE = false
 # automatic
 ?D = $(patsubst %/,%,$(dir $?))
-# environment
-rvm_path = /Users/lee/.rvm
 # automatic
 @D = $(patsubst %/,%,$(dir $@))
 # automatic
 @F = $(notdir $@)
 # makefile
-CURDIR := /Users/lee/code/meshery-nginx-sm
+CURDIR := /Users/ashishtiwari/dev/meshery-nginx-sm
 # makefile
 SHELL = /bin/sh
 # environment
-VSCODE_NLS_CONFIG = {"locale":"en-us","availableLanguages":{},"_languagePackSupport":true}
+VSCODE_NLS_CONFIG = {"locale":"en-gb","availableLanguages":{},"_languagePackSupport":true}
 # environment
 _ = /usr/bin/make
 # makefile (from `Makefile', line 1)
@@ -44,19 +47,19 @@ VSCODE_VERBOSE_LOGGING = true
 # environment
 __CFBundleIdentifier = com.microsoft.VSCode
 # environment
-VSCODE_IPC_HOOK_EXTHOST = /var/folders/jn/qfb6lgmj7yq32km_vjbln42h0000gn/T/vscode-ipc-1fc6c6f3-8d32-4d6c-b7b5-ca24e9a4c802.sock
+INFOPATH = /opt/homebrew/share/info:
 # environment
-VSCODE_CWD = /
+VSCODE_IPC_HOOK_EXTHOST = /var/folders/lk/9scd6b7x2g10jnpjfxdghmgw0000gn/T/vscode-ipc-0b01e683-393b-4c86-9331-5eb2b6fdd1dc.sock
+# environment
+VSCODE_CWD = /Users/ashishtiwari/dev/meshery-nginx-sm
 # environment
 GOPROXY = https://proxy.golang.org,direct
 # environment
-PATH = /Users/lee/.rvm/gems/ruby-2.6.3/bin:/Users/lee/.rvm/gems/ruby-2.6.3@global/bin:/Users/lee/.rvm/rubies/ruby-2.6.3/bin:/Users/lee/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin:/Users/lee/code/go/bin:/Users/lee/.istioctl/bin:/Users/lee/.rvm/bin:/Users/lee/.rvm/bin
+PATH = /opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/ashishtiwari/dev/useful-go-func/copyjsonyaml:/usr/local/go/bin
 # environment
 LSCOLORS = Gxfxcxdxbxegedabagacad
 # environment
-rvm_stored_umask = 022
-# environment
-GOPATH = /Users/lee/code/go
+GOPATH = /Users/ashishtiwari/go
 # environment
 VSCODE_LOG_STACK = false
 # environment
@@ -64,39 +67,41 @@ ELECTRON_RUN_AS_NODE = 1
 # default
 .FEATURES := target-specific order-only second-expansion else-if archives jobserver check-symlink
 # environment
-SSH_AUTH_SOCK = /private/tmp/com.apple.launchd.QxBJqZxcz9/Listeners
+SSH_AUTH_SOCK = /private/tmp/com.apple.launchd.fJIbZC7szn/Listeners
 # automatic
 %F = $(notdir $%)
 # environment
 VSCODE_PIPE_LOGGING = true
 # environment
-rvm_bin_path = /Users/lee/.rvm/bin
+PWD = /Users/ashishtiwari/dev/meshery-nginx-sm
 # environment
-PWD = /Users/lee/code/meshery-nginx-sm
-# environment
-GEM_HOME = /Users/lee/.rvm/gems/ruby-2.6.3
+HOMEBREW_CELLAR = /opt/homebrew/Cellar
 # environment
 ORIGINAL_XDG_CURRENT_DESKTOP = undefined
 # environment
-GOMODCACHE = /Users/lee/code/go/pkg/mod
+MANPATH = /opt/homebrew/share/man::
 # environment
-HOME = /Users/lee
+GOMODCACHE = /Users/ashishtiwari/go/pkg/mod
+# environment
+HOME = /Users/ashishtiwari
 # default
 MAKEFILEPATH = $(shell /usr/bin/xcode-select -print-path 2>/dev/null || echo /Developer)/Makefiles
 # environment
-VSCODE_CODE_CACHE_PATH = /Users/lee/Library/Application Support/Code/CachedData/c722ca6c7eed3d7987c0d5c3df5c45f6b15e77d1
+VSCODE_CLI = 1
 # environment
-LOGNAME = lee
+VSCODE_CODE_CACHE_PATH = /Users/ashishtiwari/Library/Application Support/Code/CachedData/30d9c6cd9483b2cc586687151bcbcd635f373630
+# environment
+LOGNAME = ashishtiwari
 # environment
 APPLICATION_INSIGHTS_NO_DIAGNOSTIC_CHANNEL = 1
 # environment
-ZSH = /Users/lee/.oh-my-zsh
+NVM_CD_FLAGS = -q
+# environment
+ZSH = /Users/ashishtiwari/.oh-my-zsh
 # environment
 VSCODE_HANDLES_UNCAUGHT_ERRORS = true
 # automatic
 ^D = $(patsubst %/,%,$(dir $^))
-# environment
-GEM_PATH = /Users/lee/.rvm/gems/ruby-2.6.3:/Users/lee/.rvm/gems/ruby-2.6.3@global
 # environment
 XPC_FLAGS = 0x0
 # default
@@ -104,31 +109,31 @@ MAKE = $(MAKE_COMMAND)
 # default
 MAKECMDGOALS := all
 # environment
-IRBRC = /Users/lee/.rvm/rubies/ruby-2.6.3/.irbrc
-# environment
-SHLVL = 1
+SHLVL = 3
 # default
 MAKE_VERSION := 3.81
 # environment
-USER = lee
+USER = ashishtiwari
 # makefile
 .DEFAULT_GOAL := protoc-setup
 # environment
-rvm_version = 1.29.9 (latest)
+TERM_SESSION_ID = 68E497C5-9872-49A9-8BE9-CE072299B38D
 # environment
 LESS = -R
 # automatic
 %D = $(patsubst %/,%,$(dir $%))
 # default
 MAKE_COMMAND := /Library/Developer/CommandLineTools/usr/bin/make
+# environment
+TERM_PROGRAM = Apple_Terminal
 # default
 .VARIABLES := 
 # environment
-TMPDIR = /var/folders/jn/qfb6lgmj7yq32km_vjbln42h0000gn/T/
+TMPDIR = /var/folders/lk/9scd6b7x2g10jnpjfxdghmgw0000gn/T/
 # automatic
 *F = $(notdir $*)
 # environment
-VSCODE_IPC_HOOK = /Users/lee/Library/Application Support/Code/1.65.2-main.sock
+VSCODE_IPC_HOOK = /Users/ashishtiwari/Library/Application Support/Code/1.68.1-main.sock
 # makefile
 MAKEFLAGS = Rrqp
 # environment
@@ -136,13 +141,19 @@ MFLAGS = -Rrqp
 # automatic
 *D = $(patsubst %/,%,$(dir $*))
 # environment
-XPC_SERVICE_NAME = application.com.microsoft.VSCode.177240131.177240137
+TERM_PROGRAM_VERSION = 444
+# environment
+NVM_DIR = /Users/ashishtiwari/.nvm
+# environment
+XPC_SERVICE_NAME = application.com.microsoft.VSCode.579759.579765.B9A6DFD3-FE7D-44DF-85A3-5EB21BF68690
+# environment
+HOMEBREW_PREFIX = /opt/homebrew
 # automatic
 +D = $(patsubst %/,%,$(dir $+))
-# environment
-rvm_user_install_flag = 1
 # automatic
 +F = $(notdir $+)
+# environment
+HOMEBREW_REPOSITORY = /opt/homebrew
 # environment
 __CF_USER_TEXT_ENCODING = 0x1F5:0x0:0x0
 # environment
@@ -157,24 +168,20 @@ PAGER = less
 LC_ALL = C
 # automatic
 ^F = $(notdir $^)
-# environment
-rvm_prefix = /Users/lee
 # default
 SUFFIXES := 
-# default
-.INCLUDE_DIRS = /usr/local/include
-# environment
-rvm_loaded_flag = 1
 # environment
 MAKELEVEL := 0
 # environment
 LANG = C
 # environment
-VSCODE_PID = 64904
+TERM = xterm-256color
 # environment
-MY_RUBY_HOME = /Users/lee/.rvm/rubies/ruby-2.6.3
+VSCODE_PID = 1763
+# environment
+NVM_RC_VERSION = 
 # variable set hash-table stats:
-# Load=81/1024=8%, Rehash=0, Collisions=3/105=3%
+# Load=83/1024=8%, Rehash=0, Collisions=2/106=2%
 
 # Pattern-specific Variable Values
 
@@ -182,9 +189,9 @@ MY_RUBY_HOME = /Users/lee/.rvm/rubies/ruby-2.6.3
 
 # Directories
 
-# . (device 16777220, inode 152956965): 22 files, no impossibilities.
+# . (device 16777232, inode 4004035): 23 files, no impossibilities.
 
-# 22 files, no impossibilities in 1 directories.
+# 23 files, no impossibilities in 1 directories.
 
 # Implicit Rules
 
@@ -215,7 +222,7 @@ all:
 # Not a target:
 Makefile:
 #  Implicit rule search has been done.
-#  Last modified 2022-03-27 09:29:39
+#  Last modified 2022-08-01 13:38:58
 #  File has been updated.
 #  Successfully updated.
 # variable set hash-table stats:
@@ -234,7 +241,7 @@ error:
 #  Implicit rule search has not been done.
 #  File does not exist.
 #  File has not been updated.
-#  commands to execute (from `Makefile', line 24):
+#  commands to execute (from `Makefile', line 29):
 	go run github.com/layer5io/meshkit/cmd/errorutil -d . analyze -i ./helpers -o ./helpers
 	
 
@@ -254,9 +261,17 @@ docker-run:
 #  commands to execute (from `Makefile', line 12):
 	(docker rm -f meshery-nginx-sm) || true
 	docker run --name meshery-nginx-sm -d \
-	-p 10007:10007 \
+	-p 10010:10010 \
 	-e DEBUG=true \
 	layer5/meshery-nginx-sm
+	
+
+run-force-dynamic-reg:
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+#  commands to execute (from `Makefile', line 25):
+	FORCE_DYNAMIC_REG=true DEBUG=true GOPROXY=direct GOSUMDB=off go run main.go
 	
 
 # Not a target:
@@ -269,9 +284,9 @@ run:
 #  Implicit rule search has not been done.
 #  Modification time never checked.
 #  File has not been updated.
-#  commands to execute (from `Makefile', line 19):
-	go mod tidy; \
-	DEBUG=true go run main.go
+#  commands to execute (from `Makefile', line 21):
+	go$(v) mod tidy -compat=1.17; \
+	DEBUG=true GOPROXY=direct GOSUMDB=off go run main.go
 	
 
 docker:
@@ -283,7 +298,7 @@ docker:
 	
 
 # files hash-table stats:
-# Load=11/1024=1%, Rehash=0, Collisions=1/24=4%
+# Load=12/1024=1%, Rehash=0, Collisions=1/25=4%
 # VPATH Search Paths
 
 # No `vpath' search paths.
@@ -295,8 +310,6 @@ docker:
 # strcache size: total = 4096 / max = 4096 / min = 4096 / avg = 4096
 # strcache free: total = 4087 / max = 4087 / min = 4087 / avg = 4087
 
-# Finished Make data base on Sun Mar 27 21:58:04 2022
+# Finished Make data base on Mon Aug  1 13:39:16 2022
 
- 
-make: *** No rule to make target `all'.  Stop.
  

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,23 +15,16 @@ COPY internal/ internal/
 COPY nginx/ nginx/
 COPY build/ build/
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s -X main.version=$VERSION -X main.gitsha=$GIT_COMMITSHA" -a -o meshery-nginx-sm main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s -X main.version=$VERSION -X main.gitsha=$GIT_COMMITSHA" -a -o meshery-nginx-sm main.go
 
-FROM alpine:3.15 as jsonschema-util
-RUN apk add --no-cache curl
-WORKDIR /
-RUN curl -LO https://github.com/layer5io/kubeopenapi-jsonschema/releases/download/v0.1.3/kubeopenapi-jsonschema
-RUN chmod +x /kubeopenapi-jsonschema
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/nodejs:14
 ENV DISTRO="debian"
-ENV GOARCH="amd64"
 ENV SERVICE_ADDR="meshery-nginx-sm"
 ENV MESHERY_SERVER="http://meshery:9081"
 COPY templates/ ./templates
 WORKDIR /
 COPY --from=builder /build/meshery-nginx-sm .
-COPY --from=jsonschema-util /kubeopenapi-jsonschema /root/.meshery/bin/kubeopenapi-jsonschema
 ENTRYPOINT ["/meshery-nginx-sm"]


### PR DESCRIPTION
Signed-off-by: Ashish Tiwari <ashishjaitiwari15112000@gmail.com>

**Description**

This PR fixes #
The KubeopenAPI binary is no longer required in the container since we have moved to GO based validation.
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
