### PR TITLE
upgrading test_adapter to v2 for all e2e centralized tests

### DIFF
--- a/.github/workflows/e2etests.yaml
+++ b/.github/workflows/e2etests.yaml
@@ -45,7 +45,7 @@ jobs:
 
   TestNginxSM:
     needs: SetPatternfile
-    uses: meshery/meshery/.github/workflows/test_adapters.yaml@master
+    uses: meshery/meshery/.github/workflows/test_adaptersv2.yaml@master
     with:
       expected_resources: nginx-mesh-api,nginx-mesh-metrics
       expected_resources_types: pod,pod


### PR DESCRIPTION
**Description**
This PR migrates the adapter to v2 for all centralized e2e tests
This PR fixes #233

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
