### PR TITLE
Update GitHub Actions workflows to use setup-go@v5

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         fetch-depth: 1
     - name: Setup Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: 1.23
     - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go build .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/setup-go@master
         with:
           go-version: 1.23
-      - uses: dominikh/staticcheck-action@v1.2.0
+      - uses: dominikh/staticcheck-action@v1.3.0
         with:
           install-go: false
           version: "2022.1"

--- a/.github/workflows/error-ref-publisher.yml
+++ b/.github/workflows/error-ref-publisher.yml
@@ -19,7 +19,7 @@ jobs:
           ref: "master"
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ secrets.GO_VERSION }}
 

--- a/.github/workflows/update-oam-defs.yml
+++ b/.github/workflows/update-oam-defs.yml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           ref: "master"
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.23
       - name: Run adapter to create components


### PR DESCRIPTION
**Description**

This PR fixes https://github.com/meshery/meshery/issues/13041, upgrading dominikh/staticcheck-action@v1 to dominikh/staticcheck-action@v1.3.0

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
