### PR TITLE
fix: update docker repository references from layer5io to meshery 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Contributing
 
-You want to contribute to the project? Yay! We want you to! Visit our centralized instructions for [contributing](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#contributing).
+You want to contribute to the project? Yay! We want you to! Visit our centralized instructions for [contributing](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#contributing).
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19 as builder
+FROM golang:1.23 as builder
 
 ARG VERSION
 ARG GIT_COMMITSHA

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 docker:
-	docker build -t layer5/meshery-nginx-sm .
+	docker build -t meshery/meshery-nginx-sm .
 
 docker-run:
 	(docker rm -f meshery-nginx-sm) || true
 	docker run --name meshery-nginx-sm -d \
 	-p 10010:10010 \
 	-e DEBUG=true \
-	layer5/meshery-nginx-sm
+	meshery/meshery-nginx-sm
 
 test:
 	go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 # Meshery Adapter for NGINX Service Mesh
 <div align="center">
 
-[![Docker Pulls](https://img.shields.io/docker/pulls/layer5/meshery-nginx-sm.svg)](https://hub.docker.com/r/layer5/meshery-nginx-sm)
-[![Go Report Card](https://goreportcard.com/badge/github.com/layer5io/meshery-nginx-sm)](https://goreportcard.com/report/github.com/layer5io/meshery-nginx-sm)
+[![Docker Pulls](https://img.shields.io/docker/pulls/meshery/meshery-nginx-sm.svg)](https://hub.docker.com/r/meshery/meshery-nginx-sm)
+[![Go Report Card](https://goreportcard.com/badge/github.com/meshery/meshery-nginx-sm)](https://goreportcard.com/report/github.com/meshery/meshery-nginx-sm)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/meshery/meshery-nginx-sm/multi-platform.yml?branch=master)](https://github.com/meshery/meshery-nginx-sm/actions)
 [![GitHub](https://img.shields.io/github/license/meshery/meshery-nginx-sm.svg)](https://github.com/meshery/meshery-nginx-sm/blob/master/LICENSE)
-[![GitHub issues by-label](https://img.shields.io/github/issues/layer5io/meshery-nginx-sm/help%20wanted.svg)](https://github.com/layer5io/meshery-nginx-sm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+[![GitHub issues by-label](https://img.shields.io/github/issues/meshery/meshery-nginx-sm/help%20wanted.svg)](https://github.com/meshery/meshery-nginx-sm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
 [![Website](https://img.shields.io/website/https/layer5.io/meshery.svg)](https://meshery.io)
 [![Twitter Follow](https://img.shields.io/twitter/follow/mesheryio.svg?label=Follow&style=social)](https://twitter.com/intent/follow?screen_name=mesheryio)
 [![Discuss Users](https://img.shields.io/discourse/users?server=https%3A%2F%2Fdiscuss.layer5.io)](https://meshery.io/community#discussion-forums)


### PR DESCRIPTION
**Description**
update docker repository references from layer5io to meshery and update docker go version to 1.23
This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
