### PR TITLE
chore: remove codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,22 +129,4 @@ jobs:
           cache-dependency-path: go.sum
       - name: go mod tidy
         run: make tidy       
-  codecov:
-    name: codecov
-    needs: [ tidy ]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-go@master
-        with:
-          go-version: '1.21'
-          cache: true
-          cache-dependency-path: go.sum
-      - name: Unit test
-        run: make test
-      - name: Upload covergae to Codecov
-        if: github.repository == 'meshery/meshery-nginx-sm'
-        uses: codecov/codecov-action@v3
-        with:
-          files: ./coverage.out
-          flags: unittests
+  


### PR DESCRIPTION
**Relation**
Part of organization-wide codecov removal effort.

**Notes for Reviewers**
- Removed codecov job from ci.yml workflow
- Tests should run via separate 'tests' job in the workflow
- Coverage generation should run locally with: make test

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
